### PR TITLE
Fix Jaro-Winkler result for two empty inputs

### DIFF
--- a/src/clj_fuzzy/jaro_winkler.cljc
+++ b/src/clj_fuzzy/jaro_winkler.cljc
@@ -63,11 +63,14 @@
 (defn- winkler-prefix [seq1 seq2]
   (loop [i 0
          prefix 0]
-    (if (< i 4)
-      (if (= (get seq1 i) (get seq2 i))
-        (recur (inc i) (inc prefix))
-        (recur 5 prefix))
-      prefix)))
+    (let [p1 (get seq1 i)
+          p2 (get seq2 i)]
+      (if (and (and (some? p1) (some? p2))
+               (< i 4))
+        (if (= p1 p2)
+          (recur (inc i) (inc prefix))
+          (recur 5 prefix))
+        prefix))))
 
 ;; Main Functions
 (defn jaro

--- a/test/clj_fuzzy/jaro_winkler_test.clj
+++ b/test/clj_fuzzy/jaro_winkler_test.clj
@@ -15,10 +15,14 @@
   (is (= 0.8222222222222223 (jaro "Dwayne" "Duane")))
   (is (= 0.9444444444444443 (jaro "Martha" "Marhta")))
   (is (= 0.7666666666666666 (jaro "Dixon" "Dicksonx")))
-  (is (= 0.4166666666666667 (jaro "Duane" "Freakishlylongstring"))))
+  (is (= 0.4166666666666667 (jaro "Duane" "Freakishlylongstring")))
+  (is (= 0 (jaro "" "")))
+  (is (= 0 (jaro nil nil))))
 
 (deftest jaro-winkler-test
-  (is (= 1.0 (jaro "Duane" "Duane")))
+  (is (= 1.0 (jaro-winkler "Duane" "Duane")))
+  (is (= 0.0 (jaro-winkler "" "")))
+  (is (= 0.0 (jaro-winkler nil nil)))
   (is (= 0.8400000000000001 (jaro-winkler "Dwayne" "Duane")))
   (is (= 0.961111111111111 (jaro-winkler "Martha" "Marhta")))
   (is (= 0.8133333333333332 (jaro-winkler "Dixon" "Dicksonx")))


### PR DESCRIPTION
Resolves https://github.com/Yomguithereal/clj-fuzzy/issues/43

After trying a few other libraries (https://github.com/kiyoka/fuzzy-string-match and
https://github.com/tonytonyjan/jaro_winkler), I've noticed that it seems more common to return 0
for two empty inputs than 1.

This PR implements and tests that behavior.