### PR TITLE
Exclude any? to remove warning with Clojure 1.9.

### DIFF
--- a/src/clj_fuzzy/helpers.cljc
+++ b/src/clj_fuzzy/helpers.cljc
@@ -7,6 +7,7 @@
 ;;   Version: 0.1
 ;;
 (ns clj-fuzzy.helpers
+  (:refer-clojure :exclude [any?])
   (:require clojure.string))
 
 ;; Strings helpers


### PR DESCRIPTION
When using with Clojure 1.9, you will receive this warning: 

```
WARNING: any? already refers to: #'clojure.core/any? in namespace: clj-fuzzy.helpers, being replaced by: #'clj-fuzzy.helpers/any?
```
Excluding `any?` prevents this warning.