### PR TITLE
Jaro - window width fix

### DIFF
--- a/src/clj_fuzzy/jaro_winkler.cljc
+++ b/src/clj_fuzzy/jaro_winkler.cljc
@@ -22,7 +22,7 @@
          nseq1-matches seq1-matches
          nseq2-matches seq2-matches]
     (if (and ((complement nil?) j)
-             (<= j window-end))
+             (< j window-end))
       (if (and (not (get seq2-matches j))
                (= ch (get shortest j)))
         (recur nil

--- a/test/clj_fuzzy/jaro_winkler_test.clj
+++ b/test/clj_fuzzy/jaro_winkler_test.clj
@@ -15,7 +15,9 @@
   (is (= 0.8222222222222223 (jaro "Dwayne" "Duane")))
   (is (= 0.9444444444444443 (jaro "Martha" "Marhta")))
   (is (= 0.7666666666666666 (jaro "Dixon" "Dicksonx")))
-  (is (= 0.4166666666666667 (jaro "Duane" "Freakishlylongstring"))))
+  (is (= 0.4166666666666667 (jaro "Duane" "Freakishlylongstring")))
+  (let [s1 "xxx1" s2 "y123"]
+    (is (= (jaro s1 s2) (jaro s2 s1)))))
 
 (deftest jaro-winkler-test
   (is (= 1.0 (jaro "Duane" "Duane")))


### PR DESCRIPTION
There was a bug. Different outputs were produced for the same input strings:
(let [s1 "xxx1" s2 "y123"]
  [(jaro s1 s2) (jaro s2 s1)])
 -> [0 0.5]